### PR TITLE
Support for running locally w/ sqlite

### DIFF
--- a/.cdsrc.json
+++ b/.cdsrc.json
@@ -1,10 +1,20 @@
 {
   "build": {
-      "target": ".",
-      "tasks": [
-        {"src":"db","for":"hana","options":{"model":["db","srv"]}},
-        {"src":"srv","for":"node-cf","options":{"model":["db","srv"]}},
-        {"src":"ui","for":"fiori","options":{"model":["db","srv","ui"]}}
-      ]
+    "target": ".",
+    "tasks": [
+      {"src":"db","for":"hana","options":{"model":["db","srv"]}},
+      {"src":"srv","for":"node-cf","options":{"model":["db","srv"]}},
+      {"src":"ui","for":"fiori","options":{"model":["db","srv","ui"]}}
+    ]
+  },
+  "requires": {
+    "[sqlite]": {
+      "db": {
+        "kind": "sqlite",
+        "credentials": {
+          "database": "db/spaceflight.db"
+        }
+      }
     }
+  }
 }

--- a/.vscode/cds.js
+++ b/.vscode/cds.js
@@ -1,0 +1,3 @@
+// used in launch.json to refer to an installed cds via an absolute path
+const cds = require ('@sap/cds')
+cds.exec()

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+
+    {
+      "type": "node", "request": "launch",
+      "name": "cds run", "args": [ "run" ],
+      "env": {"DEBUG":"yes", "CDS_ENV": "sqlite"},                // <-- we set the 'sqlite' profile
+      "program": "${workspaceFolder}/.vscode/cds", "skipFiles": [
+          "<node_internals>/**/*.js",
+          "**/cds-reflect/lib/index.js",
+          "**/cds/lib/index.js",
+          "**/.vscode/cds.js",
+      ],
+      "console": "integratedTerminal"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "express": "^4.16.3",
     "spaceflight-model": "git://github.com/SAP/cloud-sample-spaceflight.git"
   },
+  "devDependencies": {
+    "sqlite3": "^4.0.6"
+  },
   "scripts": {
     "start": "cds run",
     "build": "cds build/all --clean",
@@ -17,9 +20,8 @@
     "requires": {
       "db": {
         "kind": "hana",
-        "model": "db"
+        "model": [ "db", "srv" ]
       }
     }
-  },
-  "private": true
+  }
 }


### PR DESCRIPTION
Change default config through an sqlite profile.  Activate it like
through `CDS_ENV` environment variable, e.g.
```sh
CDS_ENV=sqlite cds run
```
The VSCode run config activates this by default.